### PR TITLE
keep mobile screen active while timer plays

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@vercel/analytics": "^1.4.1",
         "next": "15.1.0",
+        "nosleep.js": "^0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "uuid": "^11.0.3"

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -18,6 +18,7 @@ import ReplayIcon from '@/../public/replay.svg';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/app/(components)/button';
 import { prettyFormatSeconds } from '@/app/util';
+import NoSleep from 'nosleep.js';
 
 export default function PlayPage() {
     // fixme: this was annoying, see https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
@@ -125,6 +126,10 @@ const HomeWithValidData = ({
         currentSection,
     ]);
 
+    const noSleep = useMemo(() => {
+        return new NoSleep();
+    }, [])
+
     return (
         <div className="flex flex-col gap-12">
             {currentSection === null ? (
@@ -151,11 +156,15 @@ const HomeWithValidData = ({
             )}
             <Controls
                 isPaused={isPaused}
-                onStart={() => setIsPaused(false)}
+                onStart={() => {
+                    setIsPaused(false)
+                    noSleep.enable();
+                }}
                 onPause={() => setIsPaused(true)}
                 onReset={() => {
                     setTotalSecondsRemaining(totalDuration);
                     setIsPaused(true);
+                    noSleep.disable();
                 }}
             />
         </div>

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -130,6 +130,15 @@ const HomeWithValidData = ({
         return new NoSleep();
     }, []);
 
+    useEffect(
+        function disableNoSleepWhenPresentationEnds() {
+            if (currentSection !== null) return;
+            if (!noSleep.isEnabled) return;
+            noSleep.disable();
+        },
+        [noSleep, currentSection]
+    );
+
     return (
         <div className="flex flex-col gap-12">
             {currentSection === null ? (

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -128,7 +128,7 @@ const HomeWithValidData = ({
 
     const noSleep = useMemo(() => {
         return new NoSleep();
-    }, [])
+    }, []);
 
     return (
         <div className="flex flex-col gap-12">
@@ -157,7 +157,7 @@ const HomeWithValidData = ({
             <Controls
                 isPaused={isPaused}
                 onStart={() => {
-                    setIsPaused(false)
+                    setIsPaused(false);
                     noSleep.enable();
                 }}
                 onPause={() => setIsPaused(true)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,6 +3224,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nosleep.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/nosleep.js/-/nosleep.js-0.12.0.tgz#a01fddab2c13af357d673928b1f40a9013a4dc08"
+  integrity sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==
+
 nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"


### PR DESCRIPTION
NoSleep.js to the rescue
closes #30 

Website will enable device wake lock when the timer is playing
Pausing does not disable the wake lock
When the presentation is over, the wake lock is automatically removed
When the presentation is reset, the wake lock is also removed